### PR TITLE
adjust xml-encoded '&' for Location header

### DIFF
--- a/API.php
+++ b/API.php
@@ -310,8 +310,8 @@ class API extends \Piwik\Plugin\API
         if ($shortCode === null) {
             throw new UnableToRedirectException(Piwik::translate('ShortcodeTracker_unable_to_perform_redirect'));
         }
-
-        header('Location: ' . $shortCode['url']);
+     
+        header('Location: ' . str_replace('amp;', '', $shortCode['url']);
     }
 
 


### PR DESCRIPTION
In the method `performRedirectForShortcode()`, adjust the xml-encoded '&amp;' for the `Location` header, replacing `'amp;'` with `''`. (