### PR TITLE
Update for Matomo 5 compatibility

### DIFF
--- a/API.php
+++ b/API.php
@@ -303,7 +303,7 @@ class API extends \Piwik\Plugin\API
 
 		$shortcode = false;
 
-		if ($useExistingCodeIfAvailable === "true")
+		if ($useExistingCodeIfAvailable === "1")
 		{
 			$shortcode = $this->getModel()->selectShortcodeByUrl($sanitizedUrl);
 		}

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -43,6 +43,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     {
         $setting = parent::getSetting($name);
         $value = $setting->getValue();
+        $value = $value ?? '';
         if (substr($value, -1) !== '/') {
             return $value . "/";
         }

--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -42,8 +42,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     public function getSlashedSetting($name)
     {
         $setting = parent::getSetting($name);
-        $value = $setting->getValue();
-        $value = $value ?? '';
+        $value = $setting->getValue() ?? '';
         if (substr($value, -1) !== '/') {
             return $value . "/";
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 ## Changelog
+* 2.0.4
+  * Compatibility with Matomo 5
+
 * 2.0.3
     * Fixed bug where API tried to access not existing subtable
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## Changelog
-* 2.0.4
+* 5.0.0
   * Compatibility with Matomo 5
 
 * 2.0.3

--- a/javascripts/rowaction.js
+++ b/javascripts/rowaction.js
@@ -34,7 +34,8 @@ DataTable_RowActions_Registry.register({
     },
 
     isAvailableOnRow: function (dataTableParams, tr) {
-        return $(tr).data('urlLabel') !== '';
+      var dataUrl = $(tr).data('url-label');
+        return typeof dataUrl !== 'undefined' && dataUrl.length > 0;
     }
 
 });

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "ShortcodeTracker",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Plugin allowing user to create shortcodes and track their usage within Piwik. Also integrates with UI to deliver user-friendly interaction.",
     "theme": false,
     "keywords": [
@@ -9,7 +9,7 @@
         "redirect"
     ],
     "require": {
-        "matomo": ">=4.0.0-b1,<5.0.0-b1"
+        "matomo": ">=5.0.0-b1,<6.0.0-b1"
     },
     "license": "GPL-3.0",
     "homepage": "http:\/\/mgazdzik.pl\/shortcodetracker",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "ShortcodeTracker",
-    "version": "2.0.4",
+    "version": "5.0.0",
     "description": "Plugin allowing user to create shortcodes and track their usage within Piwik. Also integrates with UI to deliver user-friendly interaction.",
     "theme": false,
     "keywords": [

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -1,15 +1,15 @@
 {% block content %}
-    <div piwik-form>
-        <h2 piwik-enriched-headline>{{ 'ShortcodeTracker_generate_shortcode_header'|translate }}</h2>
+    <div class="card"><div class="card-content">
+        <h2 class="card-title">{{ 'ShortcodeTracker_generate_shortcode_header'|translate }}</h2>
 
         <form>
-            <div piwik-field uicontrol="text" name="url_to_shorten"
+            <div vue-entry="CorePluginsAdmin.Field" uicontrol="text" name="url_to_shorten"
                  title="{{ 'ShortcodeTracker_input_url'|translate }}"
                  introduction="{{ 'ShortcodeTracker_url_to_shorten'|translate }}"
                  placeholder="ex. http://piwik.com">
             </div>
 
-            <div piwik-field uicontrol="checkbox" name="useExistingShortcodeIfAvailable"
+            <div vue-entry="CorePluginsAdmin.Field" uicontrol="checkbox" name="useExistingShortcodeIfAvailable"
                  title="{{ 'ShortcodeTracker_use_existing_shortcode_help'|translate }}"
                  introduction="{{ 'ShortcodeTracker_use_existing_shortcode_if_available'|translate }}"
                  >
@@ -20,7 +20,7 @@
             <input type="button" class="btn" value="{{ 'ShortcodeTracker_generate_shortcode'|translate }}"
                    id="url_to_shorten_submit"/>
         </form>
-    </div>
+    </div></div>
     {% import 'ajaxMacros.twig' as ajax %}
     {{ ajax.errorDiv('ajaxErrorShortcodeTrakcer') }}
     {{ ajax.loadingDiv('ajaxLoadingShortcodeTracker') }}


### PR DESCRIPTION
Dear Matomo Plugin Author,
We are excited that Matomo 5.0.0 is on the horizon, and we would greatly appreciate your assistance in ensuring that your plugin remains compatible with this upcoming release. Maintaining compatibility will enable Matomo users to seamlessly use your plugin after they upgrade to Matomo 5. (If the plugin is not updated to be compatible with Matomo 5, then whenever a user will upgrade to Matomo 5, the plugin would be automatically disabled to prevent issues.)

Updating your plugin to be Matomo 5 compatible is a straightforward process and should not require a significant time investment. You can find more information about updating your plugin at: https://developer.matomo.org/guides/migrate-matomo-4-to-5

Thank you for your ongoing support and commitment to the Matomo community. 
Your contribution is really appreciated!

The Matomo Team

PS: we’re also available to help if you have any question about making the plugin compatible.

> I took the liberty of forking this project and making the necessary changes. If you create a `5.x-dev` branch, rebase this PR to that branch, merge the PR, and create a new release, you should be good to go. **NOTE:** The reason I advise creating a new `5.x-dev` branch instead of merging into master is so that you can continue to maintain your plugin for older versions of Matomo.