### PR TITLE
Prevent undefined index warning

### DIFF
--- a/API.php
+++ b/API.php
@@ -475,7 +475,7 @@ class API extends \Piwik\Plugin\API
 		$filter = new DataTable\Filter\ColumnCallbackAddColumn($report, 'label', 'shortcode_url', (function ($code) use ($model) {
 			$shortcode = $model->selectShortcodeByCode($code);
 
-			return $shortcode['url'];
+			return $shortcode['url'] ?? '';
 		}));
 
 		$filter->filter($report);


### PR DESCRIPTION
Prevent undefined index warning, don't know why exactly this is triggered but this will prevent the warning. I'm not sure if there is a better value to return on error.